### PR TITLE
Add a method for cancelling all subscribing streams

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,12 @@ export interface ResumableStreamContext {
    * @returns null if there is no stream with the given streamId. True if a stream with the given streamId exists. "DONE" if the stream is fully done.
    */
   hasExistingStream: (streamId: string) => Promise<null | true | "DONE">;
+
+  /**
+   * Cancels a stream. This affects all listener.
+   * @param streamId - The ID of the stream.
+   */
+  cancelStream: (streamId: string) => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
Hi, folks! Thanks for the great lib. I had this use case for cancelling multiple subscribing streams -- here's my implementation:

When cancelling, we publish a cancel event that calls `reader.cancel`. This will cause

`reader.read().then(async ({ done, value }) => {`

`done` to be true here and follows the normal done flow.

I also released the reader lock because I needed to assert the state of the original stream in the new test case. This is probably useful for library user in the future too if they wanna do something with it after.

