### PR TITLE
feat: Introduce Explicit, AbortSignal-based Stream Cancellation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,8 @@ export interface ResumableStreamContext {
   resumableStream: (
     streamId: string,
     makeStream: () => ReadableStream<string>,
-    skipCharacters?: number
+    skipCharacters?: number,
+    cancellationController?: AbortController
   ) => Promise<ReadableStream<string> | null>;
   /**
    * Resumes a stream that was previously created by `createNewResumableStream`.
@@ -65,7 +66,8 @@ export interface ResumableStreamContext {
   createNewResumableStream: (
     streamId: string,
     makeStream: () => ReadableStream<string>,
-    skipCharacters?: number
+    skipCharacters?: number,
+    cancellationController?: AbortController
   ) => Promise<ReadableStream<string> | null>;
 
   /**
@@ -74,6 +76,14 @@ export interface ResumableStreamContext {
    * @returns null if there is no stream with the given streamId. True if a stream with the given streamId exists. "DONE" if the stream is fully done.
    */
   hasExistingStream: (streamId: string) => Promise<null | true | "DONE">;
+
+  /**
+   * Publishes a cancellation signal to the specified stream's control channel,
+   * triggering any AbortController linked during the stream's creation.
+   *
+   * @param streamId - The ID of the stream to cancel.
+   */
+  sendCancellationSignal: (streamId: string) => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
#### **What this PR solves:**

Currently, there is no way to explicitly cancel a running stream producer. This leads to wasted resources if a client intentionally aborts an operation (e.g., a user clicks a "Stop" button on a long-running AI generation).

This PR introduces opt-in mechanism to terminate a stream producer using the standard `AbortController` / `AbortSignal` pattern.

#### **Key Changes:**

*   **New Method:** A `sendCancellationSignal(streamId)` method is added to the context to trigger a cancellation from a separate request (e.g., an `/api/abort` endpoint).

*   **Backwards-Compatible API Extension:** The `createNewResumableStream` and `resumableStream` methods now accept a new, optional final argument: `cancellationController?: AbortController`. Existing calls are unaffected.

*   **Reliability:** The cancellation signal is made durable using a dual Redis mechanism: a Pub/Sub channel for real-time signals and a separate state key to solve the race condition where a signal is sent before the stream producer is fully initialized.

*   **Graceful Shutdown:** The stream producer now correctly handles `AbortError`, treating it as a normal stream completion instead of causing a server crash.

#### **Request for Feedback:**

Is this approach of extending the existing methods with an optional `AbortController` and using a dual Redis mechanism for reliability the right direction for the library?

I'm open to any and all feedback on the API design and implementation. Thank you