### PR TITLE
Better debug toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,7 @@ const streamContext = createResumableStreamContext({
 - When a second resumable stream is invoked for a given `streamId`, it publishes a messages to alert the producer that it would like to receive the stream.
 - The second consumer now expects messages of stream content via the pubsub.
 - The producer receives the request, and starts publishing the buffered messages and then publishes additional chunks of the stream.
+
+## Debugging
+
+Set the `DEBUG` environment variable to `resumable-stream:*` to see debug logs.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -331,9 +331,22 @@ function incrOrDone(publisher: Publisher, key: string): Promise<typeof DONE_VALU
   });
 }
 
+// Check if resumable-stream namespace is enabled
+// Supports: DEBUG=*, DEBUG=resumable-stream:*, DEBUG=*,other-namespace, etc.
+// note, this duplicates logic from the `debug` package
+// which we are not adding as a dependency for security reasons.
 function isDebug() {
-  return process.env.DEBUG;
+  const debug = process.env.DEBUG;
+  if (!debug) return false;
+
+  const namespaces = debug.split(',').map(ns => ns.trim());
+  return namespaces.some(ns =>
+    ns === '*' ||
+    ns === 'resumable-stream' ||
+    ns.startsWith('resumable-stream:')
+  );
 }
+
 
 function debugLog(...messages: unknown[]) {
   if (isDebug()) {


### PR DESCRIPTION
This fixes an issue where any setting of the DEBUG env var would cause the library to log potentially sensitive information. 

This clashes with the popular npm debug library which uses the same env var.

The solution introduces a namespace, that is compatible with that library. It also supports DEBUG=*.

Due to a recent security alert, the 'debug' package itself is *not* brought in as a dependency.