### PR TITLE
Add typesVersions to support node moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
     "./ioredis": "./dist/ioredis.js",
     "./redis": "./dist/redis.js"
   },
+  "typesVersions": {
+    "*": {
+      "ioredis": ["dist/ioredis.d.ts"],
+      "redis": ["dist/redis.d.ts"]
+    }
+  },
   "scripts": {
     "test": "DEBUG=1 vitest",
     "test:watch": "vitest watch",


### PR DESCRIPTION
When importing from a module using `"moduleResolution":"node"`, the following error would be emitted:

```
error TS2307: Cannot find module 'resumable-stream/ioredis' or its corresponding type declarations.
  There are types at 'node_modules/resumable-stream/dist/ioredis.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

import { createResumableStreamContext } from 'resumable-stream/ioredis';
```