### PR TITLE
Fix double-connect when using the default clients for ioredis

### DIFF
--- a/src/__tests__/ioredis.test.ts
+++ b/src/__tests__/ioredis.test.ts
@@ -3,12 +3,24 @@ import { resumableStreamTests } from "./tests";
 import Redis from "ioredis";
 
 if (process.env.REDIS_URL) {
-  resumableStreamTests(() => {
-    return {
-      subscriber: new Redis(process.env.REDIS_URL!),
-      publisher: new Redis(process.env.REDIS_URL!),
-    };
-  }, "ioredis");
+  describe("default client", () => {
+    resumableStreamTests(() => {
+      // Will obtain credentials from the REDIS_URL environment variable automatically
+      return {
+          subscriber: undefined,
+          publisher: undefined,
+        };
+      }, "ioredis");
+  });
+
+  describe("custom client", () => {
+    resumableStreamTests(() => {
+      return {
+        subscriber: new Redis(process.env.REDIS_URL!),
+        publisher: new Redis(process.env.REDIS_URL!),
+      };
+    }, "ioredis");
+  });
 } else {
   console.error("REDIS_URL is not set, skipping tests");
   describe("Redis tests", () => {

--- a/src/ioredis-adapters.ts
+++ b/src/ioredis-adapters.ts
@@ -8,7 +8,10 @@ import { Publisher, Subscriber } from "./types";
  */
 export function createSubscriberAdapter(client: Redis): Subscriber {
   const adapter: Subscriber = {
-    connect: () => client.connect(),
+    connect: () => {
+      // ioredis Redis instances are connected by default. Nothing to do.
+      return Promise.resolve();
+    },
     subscribe: async function (channel: string, callback: (message: string) => void) {
       client.on("message", (innerChannel, message) => {
         if (channel === innerChannel) {
@@ -29,7 +32,10 @@ export function createSubscriberAdapter(client: Redis): Subscriber {
  */
 export function createPublisherAdapter(client: Redis): Publisher {
   const adapter: Publisher = {
-    connect: () => client.connect(),
+    connect: () => {
+      // ioredis Redis instances are connected by default. Nothing to do.
+      return Promise.resolve();
+    },
     publish: (channel: string, message: string | Buffer) => client.publish(channel, message),
     set: (key: string, value: string | Buffer, options?: { EX?: number }) => {
       if (options?.EX) {


### PR DESCRIPTION
I was getting this error when creating a resumableStreamContext

```
Redis is already connecting/connected
```

The new tests were failing before the fix.

ioredis will connect clients automatically when constructed https://github.com/redis/ioredis/blob/main/README.md#basic-usage