### PR TITLE
fix: set sentinel after subscribe to avoid race condition

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -59,13 +59,8 @@ export function createResumableStreamContextFactory(defaults: _Private.RedisDefa
         makeStream: () => ReadableStream<string>,
         skipCharacters?: number
       ): Promise<ReadableStream<string> | null> => {
-        const initPromise = Promise.all(initPromises);
-        await initPromise;
-        await ctx.publisher.set(`${ctx.keyPrefix}:sentinel:${streamId}`, "1", {
-          EX: 24 * 60 * 60,
-        });
         return createNewResumableStream(
-          initPromise,
+          Promise.all(initPromises),
           ctx as CreateResumableStreamContext,
           streamId,
           makeStream
@@ -140,8 +135,9 @@ async function createNewResumableStream(
     })
   );
   let isDone = false;
-  // This is ultimately racy if two requests for the same ID come at the same time.
-  // But this library is for the case where that would not happen.
+  // Subscribe to request channel BEFORE setting sentinel to avoid race condition.
+  // If we set sentinel first, a consumer might detect it and send a request
+  // before we've subscribed, causing the message to be lost.
   await ctx.subscriber.subscribe(
     `${ctx.keyPrefix}:request:${streamId}`,
     async (message: string) => {
@@ -163,6 +159,11 @@ async function createNewResumableStream(
       await Promise.all(promises);
     }
   );
+
+  // Set sentinel AFTER subscribing to ensure we're ready to receive requests
+  await ctx.publisher.set(`${ctx.keyPrefix}:sentinel:${streamId}`, "1", {
+    EX: 24 * 60 * 60,
+  });
 
   return new ReadableStream<string>({
     start(controller) {


### PR DESCRIPTION
## Summary

Fixes a race condition where consumers could miss the producer's request channel subscription.

## Problem

Previously, the sentinel key was set **before** subscribing to the request channel:

```mermaid
sequenceDiagram
    participant P as Producer
    participant R as Redis
    participant C as Consumer

    P->>R: SET sentinel = "1"
    Note over P: Haven't subscribed yet...
    C->>R: GET sentinel
    R-->>C: "1" (exists)
    C->>R: SUBSCRIBE chunk:listenerId
    C->>R: PUBLISH request:streamId
    Note over R: ❌ No subscriber, message lost!
    P->>R: SUBSCRIBE request:streamId
    Note over P: Too late...
    C--xC: Timeout (1s)
```

## Solution

Move sentinel set to **after** the subscribe completes:

```mermaid
sequenceDiagram
    participant P as Producer
    participant R as Redis
    participant C as Consumer

    P->>R: SUBSCRIBE request:streamId
    Note over P: ✅ Subscribe first
    P->>R: SET sentinel = "1"
    Note over P: Then set sentinel
    C->>R: GET sentinel
    R-->>C: "1" (exists)
    C->>R: SUBSCRIBE chunk:listenerId
    C->>R: PUBLISH request:streamId
    R-->>P: Received listenerId
    P->>R: PUBLISH chunk:listenerId
    R-->>C: Received data
    Note over C: ✅ Stream works!
```

## Changes

- Moved `ctx.publisher.set(sentinel)` from `createNewResumableStream` wrapper to inside the actual function, after `ctx.subscriber.subscribe()` completes
- Updated comments to explain the ordering requirement

## Testing

All existing tests pass.