### PR TITLE
fix: add missing return after resolve(null) in resumeStream timeout

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -267,6 +267,7 @@ export async function resumeStream(
             const val = await ctx.publisher.get(`${ctx.keyPrefix}:sentinel:${streamId}`);
             if (val === DONE_VALUE) {
               resolve(null);
+              return;
             }
             if (Date.now() - start > 1000) {
               controller.error(new Error("Timeout waiting for ack"));


### PR DESCRIPTION
## Summary
- Adds missing `return` after `resolve(null)` in the `resumeStream` timeout handler
- Without it, when the sentinel is `DONE_VALUE`, execution falls through to the timeout error check, calling `controller.error()` and `reject()` on an already-resolved promise