### PR TITLE
add configurable acknowledgement timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ import { after } from "next/server";
 const streamContext = createResumableStreamContext({
   waitUntil: after,
   // Optionally pass in your own Redis publisher and subscriber
+  // Optional: increase this if listener acknowledgements can exceed 1s in your environment.
+  ackTimeoutMs: 2_500,
 });
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ streamId: string }> }) {
@@ -52,6 +54,7 @@ import { after } from "next/server";
 const streamContext = createResumableStreamContext({
   waitUntil: after,
   // Optionally pass in your own Redis publisher and subscriber
+  ackTimeoutMs: 2_500,
 });
 
 export async function POST(
@@ -97,6 +100,7 @@ import { createResumableStreamContext } from "resumable-stream/ioredis";
 const streamContext = createResumableStreamContext({
   waitUntil: after,
   // Optionally pass in your own Redis publisher and subscriber
+  ackTimeoutMs: 2_500,
 });
 ```
 
@@ -110,27 +114,46 @@ import type { Publisher, Subscriber } from "resumable-stream/generic";
 
 // Example: Create adapters for your Redis client
 const publisher: Publisher = {
-  connect: async () => { /* ... */ },
-  publish: async (channel, message) => { /* ... */ },
-  set: async (key, value, options) => { /* ... */ },
-  get: async (key) => { /* ... */ },
-  incr: async (key) => { /* ... */ },
+  connect: async () => {
+    /* ... */
+  },
+  publish: async (channel, message) => {
+    /* ... */
+  },
+  set: async (key, value, options) => {
+    /* ... */
+  },
+  get: async (key) => {
+    /* ... */
+  },
+  incr: async (key) => {
+    /* ... */
+  },
 };
 
 const subscriber: Subscriber = {
-  connect: async () => { /* ... */ },
-  subscribe: async (channel, callback) => { /* ... */ },
-  unsubscribe: async (channel) => { /* ... */ },
+  connect: async () => {
+    /* ... */
+  },
+  subscribe: async (channel, callback) => {
+    /* ... */
+  },
+  unsubscribe: async (channel) => {
+    /* ... */
+  },
 };
 
 const streamContext = createResumableStreamContext({
   waitUntil: after,
   publisher,
   subscriber,
+  ackTimeoutMs: 2_500,
 });
 ```
 
 **Note:** When using the generic interface, both `publisher` and `subscriber` are **required**. The library will throw an error if they are not provided.
+
+`ackTimeoutMs` controls how long a resumed listener waits for the producer to acknowledge it before failing. It defaults to `1_000`, which preserves the previous behavior.
 
 ## Type Docs
 

--- a/docs/interfaces/CreateResumableStreamContextOptions.md
+++ b/docs/interfaces/CreateResumableStreamContextOptions.md
@@ -8,6 +8,15 @@
 
 ## Properties
 
+### ackTimeoutMs?
+
+> `optional` **ackTimeoutMs**: `number`
+
+How long to wait for the producer to acknowledge a resumed listener before failing.
+Defaults to `1_000`.
+
+***
+
 ### keyPrefix?
 
 > `optional` **keyPrefix**: `string`

--- a/src/__tests__/generic.test.ts
+++ b/src/__tests__/generic.test.ts
@@ -6,7 +6,7 @@ import { streamToBuffer, createTestingStream } from "../../testing-utils/testing
 describe("generic interface", () => {
   it("should work with custom publisher/subscriber implementations", async () => {
     const { publisher, subscriber } = createInMemoryPubSubForTesting();
-    
+
     const ctx = createResumableStreamContext({
       waitUntil: null,
       publisher,
@@ -16,7 +16,7 @@ describe("generic interface", () => {
 
     const { readable, writer } = createTestingStream();
     const stream = await ctx.resumableStream("test-stream", () => readable);
-    
+
     writer.write("Hello ");
     writer.write("World!");
     writer.close();
@@ -28,7 +28,7 @@ describe("generic interface", () => {
 
   it("should resume streams with custom implementations", async () => {
     const { publisher, subscriber } = createInMemoryPubSubForTesting();
-    
+
     const ctx = createResumableStreamContext({
       waitUntil: null,
       publisher,
@@ -39,7 +39,7 @@ describe("generic interface", () => {
     const { readable, writer } = createTestingStream();
     // Create initial stream
     const stream1 = await ctx.resumableStream("test-stream-2", () => readable);
-    
+
     // Resume the same stream immediately
     const stream2 = await ctx.resumableStream("test-stream-2", () => {
       throw new Error("Should not be called");
@@ -51,7 +51,7 @@ describe("generic interface", () => {
 
     expect(stream1).not.toBeNull();
     expect(stream2).not.toBeNull();
-    
+
     const result1 = await streamToBuffer(stream1!);
     const result2 = await streamToBuffer(stream2!);
     expect(result1).toBe("Part 1 Part 2");
@@ -60,7 +60,7 @@ describe("generic interface", () => {
 
   it("should return null if stream is done", async () => {
     const { publisher, subscriber } = createInMemoryPubSubForTesting();
-    
+
     const ctx = createResumableStreamContext({
       waitUntil: null,
       publisher,
@@ -70,17 +70,17 @@ describe("generic interface", () => {
 
     const { readable, writer } = createTestingStream();
     const stream = await ctx.resumableStream("test-stream-3", () => readable);
-    
+
     writer.write("Done");
     writer.close();
-    
+
     await streamToBuffer(stream!);
-    
+
     // Try to resume after stream is done
     const doneStream = await ctx.resumableStream("test-stream-3", () => {
       throw new Error("Should not be called");
     });
-    
+
     expect(doneStream).toBeNull();
   });
 
@@ -92,5 +92,70 @@ describe("generic interface", () => {
       });
     }).toThrow();
   });
-});
 
+  it("should use the default ack timeout", async () => {
+    const keyPrefix = "test-generic-" + crypto.randomUUID();
+    const { publisher, subscriber } = createInMemoryPubSubForTesting({
+      deliveryDelayMs: (channel) => (channel.startsWith(`${keyPrefix}:rs:chunk:`) ? 1_100 : 0),
+    });
+
+    const ctx = createResumableStreamContext({
+      waitUntil: null,
+      publisher,
+      subscriber,
+      keyPrefix,
+    });
+
+    const { readable, writer } = createTestingStream();
+    const stream = await ctx.resumableStream("test-stream-ack-default", () => readable);
+
+    await expect(
+      ctx.resumableStream("test-stream-ack-default", () => {
+        throw new Error("Should not be called");
+      })
+    ).rejects.toThrow("Timeout waiting for ack");
+
+    writer.close();
+    await streamToBuffer(stream!);
+  });
+
+  it("should allow a custom ack timeout", async () => {
+    const keyPrefix = "test-generic-" + crypto.randomUUID();
+    const { publisher, subscriber } = createInMemoryPubSubForTesting({
+      deliveryDelayMs: (channel) => (channel.startsWith(`${keyPrefix}:rs:chunk:`) ? 1_100 : 0),
+    });
+
+    const ctx = createResumableStreamContext({
+      waitUntil: null,
+      publisher,
+      subscriber,
+      keyPrefix,
+      ackTimeoutMs: 1_500,
+    });
+
+    const { readable, writer } = createTestingStream();
+    const stream1 = await ctx.resumableStream("test-stream-ack-custom", () => readable);
+    const stream2 = await ctx.resumableStream("test-stream-ack-custom", () => {
+      throw new Error("Should not be called");
+    });
+
+    writer.write("Hello");
+    writer.close();
+
+    expect(await streamToBuffer(stream1!)).toBe("Hello");
+    expect(await streamToBuffer(stream2!)).toBe("Hello");
+  });
+
+  it("should validate ackTimeoutMs", () => {
+    for (const ackTimeoutMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => {
+        createResumableStreamContext({
+          waitUntil: null,
+          publisher: createInMemoryPubSubForTesting().publisher,
+          subscriber: createInMemoryPubSubForTesting().subscriber,
+          ackTimeoutMs,
+        });
+      }).toThrow("ackTimeoutMs must be a positive finite number");
+    }
+  });
+});

--- a/src/generic.ts
+++ b/src/generic.ts
@@ -6,12 +6,13 @@ export { resumeStream } from "./runtime";
 
 /**
  * Creates a global context for resumable streams from which you can create resumable streams.
- * 
+ *
  * This generic version requires you to provide your own Publisher and Subscriber implementations,
  * making it compatible with any Redis-like client (Upstash Redis, Valkey, etc.).
  *
  * @param options - The context options.
  * @param options.keyPrefix - The prefix for the keys used by the resumable streams. Defaults to `resumable-stream`.
+ * @param options.ackTimeoutMs - How long to wait for a resumed listener acknowledgement before failing. Defaults to `1_000`.
  * @param options.waitUntil - A function that takes a promise and ensures that the current program stays alive until the promise is resolved.
  * @param options.subscriber - A pubsub subscriber implementing the Subscriber interface. **Required**.
  * @param options.publisher - A pubsub publisher implementing the Publisher interface. **Required**.
@@ -29,4 +30,3 @@ export const createResumableStreamContext = createResumableStreamContextFactory(
     );
   },
 });
-

--- a/src/ioredis.ts
+++ b/src/ioredis.ts
@@ -13,6 +13,7 @@ export { resumeStream } from "./runtime";
  *
  * @param options - The context options.
  * @param options.keyPrefix - The prefix for the keys used by the resumable streams. Defaults to `resumable-stream`.
+ * @param options.ackTimeoutMs - How long to wait for a resumed listener acknowledgement before failing. Defaults to `1_000`.
  * @param options.waitUntil - A function that takes a promise and ensures that the current program stays alive until the promise is resolved.
  * @param options.subscriber - A pubsub subscriber. Designed to be compatible with clients from the `redis` package. If not provided, a new client will be created based on REDIS_URL or KV_URL environment variables.
  * @param options.publisher - A pubsub publisher. Designed to be compatible with clients from the `redis` package. If not provided, a new client will be created based on REDIS_URL or KV_URL environment variables.

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -12,6 +12,7 @@ export { resumeStream } from "./runtime";
  *
  * @param options - The context options.
  * @param options.keyPrefix - The prefix for the keys used by the resumable streams. Defaults to `resumable-stream`.
+ * @param options.ackTimeoutMs - How long to wait for a resumed listener acknowledgement before failing. Defaults to `1_000`.
  * @param options.waitUntil - A function that takes a promise and ensures that the current program stays alive until the promise is resolved.
  * @param options.subscriber - A pubsub subscriber. Designed to be compatible with clients from the `redis` package. If not provided, a new client will be created based on REDIS_URL or KV_URL environment variables.
  * @param options.publisher - A pubsub publisher. Designed to be compatible with clients from the `redis` package. If not provided, a new client will be created based on REDIS_URL or KV_URL environment variables.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -6,18 +6,23 @@ import { createPublisherAdapter, createSubscriberAdapter } from "./ioredis-adapt
 
 interface CreateResumableStreamContext {
   keyPrefix: string;
+  ackTimeoutMs: number;
   waitUntil: (promise: Promise<unknown>) => void;
   subscriber: Subscriber;
   publisher: Publisher;
 }
 
+const DEFAULT_ACK_TIMEOUT_MS = 1_000;
+
 export function createResumableStreamContextFactory(defaults: _Private.RedisDefaults) {
   return function createResumableStreamContext(
     options: CreateResumableStreamContextOptions
   ): ResumableStreamContext {
+    const ackTimeoutMs = getAckTimeoutMs(options.ackTimeoutMs);
     const waitUntil = options.waitUntil || (async (p) => await p);
     const ctx = {
       keyPrefix: `${options.keyPrefix || "resumable-stream"}:rs`,
+      ackTimeoutMs,
       waitUntil,
       subscriber: options.subscriber,
       publisher: options.publisher,
@@ -267,12 +272,13 @@ export async function resumeStream(
             const val = await ctx.publisher.get(`${ctx.keyPrefix}:sentinel:${streamId}`);
             if (val === DONE_VALUE) {
               resolve(null);
+              return;
             }
-            if (Date.now() - start > 1000) {
+            if (Date.now() - start > ctx.ackTimeoutMs) {
               controller.error(new Error("Timeout waiting for ack"));
               reject(new Error("Timeout waiting for ack"));
             }
-          }, 1000);
+          }, ctx.ackTimeoutMs);
           await ctx.subscriber.subscribe(
             `${ctx.keyPrefix}:chunk:${listenerId}`,
             async (message: string) => {
@@ -320,6 +326,14 @@ export async function resumeStream(
       },
     });
   });
+}
+
+function getAckTimeoutMs(ackTimeoutMs: number | undefined): number {
+  const value = ackTimeoutMs ?? DEFAULT_ACK_TIMEOUT_MS;
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("ackTimeoutMs must be a positive finite number");
+  }
+  return value;
 }
 
 function incrOrDone(publisher: Publisher, key: string): Promise<typeof DONE_VALUE | number> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,11 @@ export interface CreateResumableStreamContextOptions {
    */
   keyPrefix?: string;
   /**
+   * How long to wait for the producer to acknowledge a resumed listener before failing.
+   * Defaults to `1_000`.
+   */
+  ackTimeoutMs?: number;
+  /**
    * A function that takes a promise and ensures that the current program stays alive
    * until the promise is resolved.
    *

--- a/testing-utils/in-memory-pubsub.ts
+++ b/testing-utils/in-memory-pubsub.ts
@@ -2,11 +2,17 @@ import type { Publisher, Subscriber } from "../src";
 
 type PubSub = Publisher & Subscriber;
 
+interface CreateInMemoryPubSubForTestingOptions {
+  deliveryDelayMs?: (channel: string, message: string) => number;
+}
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function createInMemoryPubSubForTesting(): {
+export function createInMemoryPubSubForTesting(
+  options: CreateInMemoryPubSubForTestingOptions = {}
+): {
   subscriber: PubSub;
   publisher: PubSub;
 } {
@@ -21,6 +27,17 @@ export function createInMemoryPubSubForTesting(): {
       await sleep(1);
       for (const callback of callbacks) {
         console.log("invoking callback", channel);
+        const deliveryDelayMs = options.deliveryDelayMs?.(channel, message) || 0;
+        if (deliveryDelayMs > 0) {
+          setTimeout(() => {
+            try {
+              callback(message);
+            } catch (e) {
+              console.error("error invoking callback", e);
+            }
+          }, deliveryDelayMs);
+          continue;
+        }
         try {
           callback(message);
         } catch (e) {


### PR DESCRIPTION
## Summary

- add optional `ackTimeoutMs` to `CreateResumableStreamContextOptions`
- default it to `1_000`, validate it as a positive finite number, and thread it through the internal runtime context
- use the configured timeout for both the resume timer and the elapsed-time timeout check
- add tests covering the default timeout, a custom timeout, and invalid timeout values
- update the README and generated type documentation

## Why

`resumeStream()` hardcoded a 1,000 ms listener acknowledgement timeout. That caused avoidable failures when Redis or pub-sub acknowledgement was delayed by transient latency.

Closes #42.

## Validation

- `corepack pnpm vitest run`
- `corepack pnpm exec typedoc`
